### PR TITLE
Add missing dependencies to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,8 @@ from setuptools import setup, find_packages
 name = PKG_NAME
 version = PKG_VERSION
 requires = [
-    'grafana-api',
+    'grafana-client',
+    'pyyaml',
     'jinja2'
 ]
 


### PR DESCRIPTION
There where two missing dependencies in the setup.py file to install grafana-tool: first the new name for grafana-api is grafana-client and it wasn't updated and it was missing the pyyaml dependency to interpret the yaml configuration file