### PR TITLE
Refactor cli.py: Improve code readability and structure by formatting…

### DIFF
--- a/examples/dashboard_export.py
+++ b/examples/dashboard_export.py
@@ -1,0 +1,47 @@
+"""
+## About
+
+Export a Grafana dashboard to a JSON file.
+
+## Walkthrough
+
+1. Start Grafana
+
+   docker run --rm -it --publish=3000:3000 --env='GF_SECURITY_ADMIN_PASSWORD=admin' grafana/grafana:11.5.2
+
+2. Create a dashboard
+
+   Open http://localhost:3000/, log in with admin:admin, and create a dashboard named `my-first-dashboard`.
+
+3. Export dashboard
+
+   python examples/dashboard_export.py my-first-dashboard my-first-dashboard.json
+"""
+
+import json
+import sys
+from pathlib import Path
+
+from grafana_import.grafana import Grafana
+
+
+def main():
+
+    # Read positional CLI arguments.
+    dashboard_name = sys.argv[1]
+    output_path = Path(sys.argv[2])
+
+    # Export dashboard JSON from Grafana.
+    # Note: Adjust parameters to match your Grafana.
+    #       You can use many variants to authenticate with its API.
+    gio = Grafana(url="http://localhost:3000", credential=("admin", "admin"))
+    dashboard = gio.export_dashboard(dashboard_name)
+
+    # Persist only the dashboard payload, just like Grafana import expects.
+    output_path.write_text(json.dumps(dashboard["dashboard"], indent=2, sort_keys=True))
+
+    print(f"Grafana dashboard exported successfully to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/dashboard_export.py
+++ b/examples/dashboard_export.py
@@ -27,6 +27,10 @@ from grafana_import.grafana import Grafana
 
 def main():
 
+    if len(sys.argv) < 3:
+        print(f"Usage: python {sys.argv[0]} <dashboard_name> <output_path>")
+        sys.exit(1)
+
     # Read positional CLI arguments.
     dashboard_name = sys.argv[1]
     output_path = Path(sys.argv[2])
@@ -38,6 +42,7 @@ def main():
     dashboard = gio.export_dashboard(dashboard_name)
 
     # Persist only the dashboard payload, just like Grafana import expects.
+    output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(json.dumps(dashboard["dashboard"], indent=2, sort_keys=True))
 
     print(f"Grafana dashboard exported successfully to {output_path}")

--- a/grafana_import/cli.py
+++ b/grafana_import/cli.py
@@ -53,6 +53,8 @@ def save_dashboard(config, args, base_path, dashboard_name, dashboard, action):
         file_name = dashboard["meta"]["folderTitle"] + "_" + file_name
 
     file_name = Grafana.remove_accents_and_space(file_name)
+    # Sanitize filename to prevent path traversal attacks
+    file_name = file_name.replace("/", "_").replace("\\", "_").replace("..", "")
     output_file = os.path.join(output_file, file_name + ".json")
 
     # Create directory structure if it doesn't exist

--- a/grafana_import/cli.py
+++ b/grafana_import/cli.py
@@ -16,6 +16,7 @@ import re
 import sys
 import traceback
 from datetime import datetime
+from pathlib import Path
 
 import grafana_client.client as GrafanaApi
 
@@ -37,44 +38,34 @@ def save_dashboard(config, args, base_path, dashboard_name, dashboard, action):
     output_file = base_path
     file_name = dashboard_name
 
-    if "exports_path" in config["general"] and not re.search(
-        r"^(\.|\/)?/", config["general"]["exports_path"]
-    ):
+    if "exports_path" in config["general"] and not re.search(r"^(\.|\/)?/", config["general"]["exports_path"]):
         output_file = os.path.join(output_file, config["general"]["exports_path"])
 
     if "export_suffix" in config["general"]:
         file_name += datetime.today().strftime(config["general"]["export_suffix"])
 
-    if (
-        "meta" in dashboard
-        and "folderId" in dashboard["meta"]
-        and dashboard["meta"]["folderId"] != 0
-    ):
+    if "meta" in dashboard and "folderId" in dashboard["meta"] and dashboard["meta"]["folderId"] != 0:
         file_name = dashboard["meta"]["folderTitle"] + "_" + file_name
 
     file_name = Grafana.remove_accents_and_space(file_name)
     # Sanitize filename to prevent path traversal attacks
     file_name = file_name.replace("/", "_").replace("\\", "_").replace("..", "")
-    output_file = os.path.join(output_file, file_name + ".json")
+    output_file = Path(output_file) / (file_name + ".json")
 
     # Create directory structure if it doesn't exist
-    output_dir = os.path.dirname(output_file)
-    if output_dir:
-        os.makedirs(output_dir, exist_ok=True)
+    output_file.parent.mkdir(parents=True, exist_ok=True)
 
+    content = (
+        json.dumps(dashboard["dashboard"], sort_keys=True, indent=2)
+        if args.pretty
+        else json.dumps(dashboard["dashboard"])
+    )
     try:
-        output = open(output_file, "w")
+        with open(output_file, "w") as output:
+            output.write(content)
     except OSError as e:
         logger.error("File {0} error: {1}.".format(output_file, e.strerror))
         sys.exit(2)
-
-    content = None
-    if args.pretty:
-        content = json.dumps(dashboard["dashboard"], sort_keys=True, indent=2)
-    else:
-        content = json.dumps(dashboard["dashboard"])
-    output.write(content)
-    output.close()
     logger.info(f"OK: Dashboard '{dashboard_name}' {action} to: {output_file}")
 
 
@@ -114,9 +105,7 @@ def main():
     setup_logging()
 
     # Get command line arguments.
-    parser = argparse.ArgumentParser(
-        description="play with grafana dashboards json files."
-    )
+    parser = argparse.ArgumentParser(description="play with grafana dashboards json files.")
 
     def print_help_and_exit():
         parser.print_help(sys.stderr)
@@ -131,16 +120,12 @@ def main():
         "allow to create a new dashboard with same name it that folder.",
     )
 
-    parser.add_argument(
-        "-b", "--base_path", help="set base directory to find default files."
-    )
+    parser.add_argument("-b", "--base_path", help="set base directory to find default files.")
     parser.add_argument("-c", "--config_file", help="path to config files.")
 
     parser.add_argument("-d", "--dashboard_name", help="name of dashboard to export.")
 
-    parser.add_argument(
-        "-u", "--grafana_url", help="Grafana URL to connect to.", required=False
-    )
+    parser.add_argument("-u", "--grafana_url", help="Grafana URL to connect to.", required=False)
 
     parser.add_argument(
         "-g",
@@ -148,9 +133,7 @@ def main():
         help="label in the config file that represents the grafana to connect to.",
     )
 
-    parser.add_argument(
-        "-f", "--grafana_folder", help="the folder name where to import into Grafana."
-    )
+    parser.add_argument("-f", "--grafana_folder", help="the folder name where to import into Grafana.")
 
     parser.add_argument(
         "-i",
@@ -251,8 +234,7 @@ def main():
         config["general"]["dashboard_name"] = args.dashboard_name
 
     if args.action == "exporter" and (
-        "dashboard_name" not in config["general"]
-        or config["general"]["dashboard_name"] is None
+        "dashboard_name" not in config["general"] or config["general"]["dashboard_name"] is None
     ):
         logger.error("ERROR: no dashboard has been specified.")
         sys.exit(1)
@@ -262,18 +244,13 @@ def main():
         config["general"]["grafana_folder"] = args.grafana_folder
         config["check_folder"] = True
 
-    if (
-        "export_suffix" not in config["general"]
-        or config["general"]["export_suffix"] is None
-    ):
+    if "export_suffix" not in config["general"] or config["general"]["export_suffix"] is None:
         config["general"]["export_suffix"] = "_%Y%m%d%H%M%S"
 
     if args.keep_uid is None:
         args.keep_uid = False
 
-    params = grafana_settings(
-        url=args.grafana_url, config=config, label=args.grafana_label
-    )
+    params = grafana_settings(url=args.grafana_url, config=config, label=args.grafana_label)
     params.update(
         {
             "overwrite": args.overwrite,
@@ -318,9 +295,7 @@ def main():
                     for f in os.listdir(import_file)
                     if os.path.isfile(os.path.join(import_file, f))
                 ]
-                logger.info(
-                    f"Found the following files: '{import_files}' in dir '{import_file}'"
-                )
+                logger.info(f"Found the following files: '{import_files}' in dir '{import_file}'")
 
         def process_dashboard(file_path):
             try:
@@ -368,9 +343,7 @@ def main():
             logger.info(f"OK: Dashboard removed: {dashboard_name}")
             sys.exit(0)
         except Grafana.GrafanaDashboardNotFoundError as exp:
-            logger.info(
-                f"KO: Dashboard not found in folder '{exp.folder}': {exp.dashboard}"
-            )
+            logger.info(f"KO: Dashboard not found in folder '{exp.folder}': {exp.dashboard}")
             sys.exit(1)
         except Grafana.GrafanaFolderNotFoundError as exp:
             logger.info(f"KO: Folder not found: {exp.folder}")
@@ -379,11 +352,7 @@ def main():
             logger.info(f"KO: Removing dashboard failed: {dashboard_name}. Reason: {exp}")
             sys.exit(1)
         except Exception:
-            logger.info(
-                "ERROR: Dashboard '{0}' remove exception '{1}'".format(
-                    dashboard_name, traceback.format_exc()
-                )
-            )
+            logger.info("ERROR: Dashboard '{0}' remove exception '{1}'".format(dashboard_name, traceback.format_exc()))
             sys.exit(1)
 
     # Export
@@ -398,11 +367,7 @@ def main():
             logger.info("KO: Dashboard name not found: {0}".format(dashboard_name))
             sys.exit(1)
         except Exception:
-            logger.info(
-                "ERROR: Dashboard '{0}' export exception '{1}'".format(
-                    dashboard_name, traceback.format_exc()
-                )
-            )
+            logger.info("ERROR: Dashboard '{0}' export exception '{1}'".format(dashboard_name, traceback.format_exc()))
             sys.exit(1)
 
         if dash is not None:
@@ -410,9 +375,7 @@ def main():
             sys.exit(0)
 
     else:
-        logger.error(
-            f"Unknown action: {args.action}. Use one of: {parser._actions[-2].choices}"
-        )
+        logger.error(f"Unknown action: {args.action}. Use one of: {parser._actions[-2].choices}")
         print_help_and_exit()
 
 

--- a/grafana_import/cli.py
+++ b/grafana_import/cli.py
@@ -52,15 +52,14 @@ def save_dashboard(config, args, base_path, dashboard_name, dashboard, action):
     file_name = file_name.replace("/", "_").replace("\\", "_").replace("..", "")
     output_file = Path(output_file) / (file_name + ".json")
 
-    # Create directory structure if it doesn't exist
-    output_file.parent.mkdir(parents=True, exist_ok=True)
-
     content = (
         json.dumps(dashboard["dashboard"], sort_keys=True, indent=2)
         if args.pretty
         else json.dumps(dashboard["dashboard"])
     )
     try:
+        # Create directory structure if it doesn't exist
+        output_file.parent.mkdir(parents=True, exist_ok=True)
         with open(output_file, "w") as output:
             output.write(content)
     except OSError as e:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@ line-length = 120
 
 [tool.ruff]
 line-length = 120
-
 lint.select = [
   # Builtins
   "A",
@@ -31,18 +30,13 @@ lint.select = [
   # flake8-2020
   "YTT",
 ]
-
-lint.extend-ignore = [
-]
-
-lint.per-file-ignores."grafana_import/cli.py" = [
-  "T201",  # `print` found
-]
-
+lint.extend-ignore = []
 lint.per-file-ignores."examples/*" = [
-  "T201",  # `print` found
+  "T201", # `print` found
 ]
-
+lint.per-file-ignores."grafana_import/cli.py" = [
+  "T201", # `print` found
+]
 # ===================
 # Tasks configuration
 # ===================
@@ -51,30 +45,27 @@ lint.per-file-ignores."tests/*" = [
   "S101",
 ]
 
-[tool.pytest.ini_options]
-addopts = "-rA --verbosity=3 --cov --cov-report=term-missing --cov-report=xml"
-minversion = "2.0"
-log_level = "DEBUG"
-log_cli_level = "DEBUG"
-log_format = "%(asctime)-15s [%(name)-24s] %(levelname)-8s: %(message)s"
-testpaths = [
+[tool.pytest]
+ini_options.addopts = "-rA --verbosity=3 --cov --cov-report=term-missing --cov-report=xml"
+ini_options.minversion = "2.0"
+ini_options.log_level = "DEBUG"
+ini_options.log_cli_level = "DEBUG"
+ini_options.log_format = "%(asctime)-15s [%(name)-24s] %(levelname)-8s: %(message)s"
+ini_options.testpaths = [
   "grafana_import",
   "tests",
 ]
-xfail_strict = true
-markers = [
-]
+ini_options.xfail_strict = true
+ini_options.markers = []
 
-[tool.coverage.run]
-branch = false
-omit = [
+[tool.coverage]
+run.branch = false
+run.omit = [
   "tests/*",
 ]
-source = [ "grafana_import" ]
-
-[tool.coverage.report]
-fail_under = 0
-show_missing = true
+run.source = [ "grafana_import" ]
+report.fail_under = 0
+report.show_missing = true
 
 [tool.mypy]
 packages = [ "grafana_import" ]
@@ -83,30 +74,25 @@ ignore_missing_imports = true
 implicit_optional = true
 non_interactive = true
 
-[tool.poe.tasks]
-
-check = [
+[tool.poe]
+tasks.check = [
   "lint",
   "test",
 ]
-
-format = [
+tasks.format = [
   { cmd = "black ." },
   # Configure Ruff not to auto-fix (remove!) unused variables (F841) and `print` statements (T201).
   { cmd = "ruff check --fix --ignore=ERA --ignore=F401 --ignore=F841 --ignore=T20 ." },
   { cmd = "pyproject-fmt --keep-full-version pyproject.toml" },
 ]
-
-lint = [
+tasks.lint = [
   { cmd = "ruff check ." },
   { cmd = "black --check ." },
   { cmd = "validate-pyproject pyproject.toml" },
   { cmd = "mypy grafana_import" },
 ]
-
-release = [
+tasks.release = [
   { cmd = "python -m build" },
   { cmd = "twine upload --skip-existing dist/*" },
 ]
-
-test = { cmd = "pytest" }
+tasks.test = { cmd = "pytest" }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -77,7 +77,7 @@ def test_export_dashboard_success(mocked_grafana, mocked_responses, caplog, use_
         m.stop()
     assert ex.match("0")
 
-    assert re.match(r".*OK: Dashboard 'foobar' exported to: ./foobar_\d+.json.*", caplog.text, re.DOTALL)
+    assert re.match(r".*OK: Dashboard 'foobar' exported to: foobar_\d+.json.*", caplog.text, re.DOTALL)
 
 
 @pytest.mark.parametrize("use_settings", [True, False], ids=["config-yes", "config-no"])


### PR DESCRIPTION
## Fix: Create directory structure before exporting dashboards

### Problem
Export operations were failing with `FileNotFoundError: [Errno 2] No such file or directory` when:
- Dashboard names contained special characters (e.g., `/`) that result in subdirectory paths
- The configured `exports_path` included nested directories that didn't exist yet

### Root Cause
The `save_dashboard()` function in `cli.py` constructed the full output file path but attempted to write the file without first ensuring the parent directory structure existed.

### Related Issue
- fixes: #40 

### Solution
Added automatic directory creation before file write operations:
```python
# Create directory structure if it doesn't exist
output_dir = os.path.dirname(output_file)
if output_dir:
    os.makedirs(output_dir, exist_ok=True)