### PR TITLE
fix: handle GrafanaUnauthorizedError with a clear error message

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,13 @@
+# https://docs.codecov.io/docs/common-recipe-list
+# https://docs.codecov.io/docs/commit-status#patch-status
+
+coverage:
+  status:
+
+    project:
+      default:
+        target: 65%
+
+    patch:
+      default:
+        informational: true

--- a/grafana_import/cli.py
+++ b/grafana_import/cli.py
@@ -232,7 +232,7 @@ def main():
     if args.dashboard_name is not None:
         config["general"]["dashboard_name"] = args.dashboard_name
 
-    if args.action == "exporter" and (
+    if args.action == "export" and (
         "dashboard_name" not in config["general"] or config["general"]["dashboard_name"] is None
     ):
         logger.error("ERROR: no dashboard has been specified.")
@@ -347,6 +347,9 @@ def main():
         except Grafana.GrafanaFolderNotFoundError as exp:
             logger.info(f"KO: Folder not found: {exp.folder}")
             sys.exit(1)
+        except GrafanaApi.GrafanaUnauthorizedError:
+            logger.error("KO: Unauthorized - check your Grafana credentials or token.")
+            sys.exit(1)
         except GrafanaApi.GrafanaBadInputError as exp:
             logger.info(f"KO: Removing dashboard failed: {dashboard_name}. Reason: {exp}")
             sys.exit(1)
@@ -364,6 +367,9 @@ def main():
             Grafana.GrafanaDashboardNotFoundError,
         ):
             logger.info("KO: Dashboard name not found: {0}".format(dashboard_name))
+            sys.exit(1)
+        except GrafanaApi.GrafanaUnauthorizedError:
+            logger.error("KO: Unauthorized - check your Grafana credentials or token.")
             sys.exit(1)
         except Exception:
             logger.info("ERROR: Dashboard '{0}' export exception '{1}'".format(dashboard_name, traceback.format_exc()))

--- a/grafana_import/grafana.py
+++ b/grafana_import/grafana.py
@@ -1,6 +1,5 @@
 import os
 import re
-import traceback
 import typing as t
 import unicodedata
 
@@ -67,7 +66,8 @@ class Grafana:
         # Configure Grafana connectivity.
         if "url" in kwargs:
             self.grafana_api = GrafanaApi.GrafanaApi.from_url(
-                url=kwargs["url"], credential=kwargs.get("credential", os.environ.get("GRAFANA_TOKEN"))
+                url=kwargs["url"],
+                credential=kwargs.get("credential", os.environ.get("GRAFANA_TOKEN")),
             )
         else:
             config = {}
@@ -116,10 +116,7 @@ class Grafana:
         # Init cache for dashboards.
         if len(Grafana.dashboards) == 0:
             # Collect all dashboard names.
-            try:
-                res = self.grafana_api.search.search_dashboards(type_="dash-db", limit=self.search_api_limit)
-            except Exception as ex:
-                raise Exception("error: {}".format(traceback.format_exc())) from ex
+            res = self.grafana_api.search.search_dashboards(type_="dash-db", limit=self.search_api_limit)
             Grafana.dashboards = res
 
         dashboards = Grafana.dashboards
@@ -168,7 +165,9 @@ class Grafana:
         except Exception as ex:
             if isinstance(ex, GrafanaClient.GrafanaClientError) and ex.status_code == 404:
                 raise GrafanaDashboardNotFoundError(
-                    dashboard_name, self.grafana_folder, f"Dashboard not found: {dashboard_name}"
+                    dashboard_name,
+                    self.grafana_folder,
+                    f"Dashboard not found: {dashboard_name}",
                 ) from ex
             raise
 


### PR DESCRIPTION
When using an invalid or expired token, the CLI was printing a confusing double-traceback instead of a useful message. This was caused by `find_dashboard()` wrapping all exceptions in a plain `Exception`, discarding the original type before it could be caught specifically.

**Changes:**
- `grafana.py`: remove the exception wrapper in `find_dashboard()` so the original type propagates unchanged
- `cli.py`: add explicit `GrafanaUnauthorizedError` handlers in `export` and `remove`, printing a clean `KO: Unauthorized - check your Grafana credentials or token.` message

**Before:**
```
❯ python3 cli.py export --pretty -d "Mimir / Alertmanager"
2026-03-15 14:10:27,649 [__main__                  ] INFO    : ERROR: Dashboard 'Mimir / Alertmanager' export exception 'Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/grafana_import/grafana.py", line 120, in find_dashboard
    res = self.grafana_api.search.search_dashboards(type_="dash-db", limit=self.search_api_limit)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/grafana_client/elements/search.py", line 71, in search_dashboards
    return self.client.GET(list_dashboard_path, params=params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/grafana_client/client.py", line 217, in __request_runner
    return self._extract_from_response(r, accept_empty_json)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/grafana_client/client.py", line 168, in _extract_from_response
    raise GrafanaUnauthorizedError(response)
grafana_client.client.GrafanaUnauthorizedError: Unauthorized

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/dominikeisenberg/Documents/Coding/OSS/grafana-import/grafana_import/cli.py", line 395, in main
    dash = grafana_api.export_dashboard(dashboard_name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/grafana_import/grafana.py", line 161, in export_dashboard
    board = self.find_dashboard(dashboard_name)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/grafana_import/grafana.py", line 122, in find_dashboard
    raise Exception("error: {}".format(traceback.format_exc())) from ex
Exception: error: Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/grafana_import/grafana.py", line 120, in find_dashboard
    res = self.grafana_api.search.search_dashboards(type_="dash-db", limit=self.search_api_limit)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/grafana_client/elements/search.py", line 71, in search_dashboards
    return self.client.GET(list_dashboard_path, params=params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/grafana_client/client.py", line 217, in __request_runner
    return self._extract_from_response(r, accept_empty_json)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/grafana_client/client.py", line 168, in _extract_from_response
    raise GrafanaUnauthorizedError(response)
grafana_client.client.GrafanaUnauthorizedError: Unauthorized

'
```

**After:**
```
KO: Unauthorized - check your Grafana credentials or token.
```

**Fixes:**
- #42 